### PR TITLE
P2P functionality

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -20,7 +20,7 @@ export const getMessages = async (req, res) => {
 
 export const sendMessage = async (req, res) => {
   try {
-    const {text, image} = req.body;
+    const {text, image, tempId} = req.body;
     const senderId = req.user._id;
     const roomName = req.params.roomName;
 
@@ -38,12 +38,15 @@ export const sendMessage = async (req, res) => {
 
     // Populate the sender information
     const populated = await Message.findById(newMessage._id)
-      .populate('senderId', 'userName color isAnonymous');
+      .populate('senderId', 'userName color isAnonymous')
+      .lean();
+
+    const payload = {...populated, tempId};    
 
     // Emit to room
-    io.to(roomName).emit("chatMessage", populated);
+    io.to(roomName).emit("chatMessage", payload);
 
-    res.status(201).json(populated);
+    res.status(201).json(payload);
   } catch (error) {
     console.log("Error in sendMessage controller: ", error.message);
     res.status(500).json({ error: "Internal server error" });

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -20,7 +20,7 @@ export const getMessages = async (req, res) => {
 
 export const sendMessage = async (req, res) => {
   try {
-    const {text, image, tempId, p2pSent} = req.body;
+    const {text, image, tempId} = req.body;
     const senderId = req.user._id;
     const roomName = req.params.roomName;
 
@@ -43,15 +43,11 @@ export const sendMessage = async (req, res) => {
 
     const payload = {...populated, tempId};    
 
-    //Only emit from server if message wasnt sent by p2p
-    if(!p2pSent) {
-      console.log(`[Server] Broadcasting message to ${roomName} as P2P fallback.`);
-      io.to(roomName).emit("chatMessage", payload);
-    } else {
-      console.log(`[Server] Message for ${roomName} persisted, broadcast skipped (sent via P2P).`);
-    }
+    // ✅ Always broadcast the message. The server is the source of truth.
+    console.log(`[Server] Broadcasting message ${payload._id} to room ${roomName}.`);
+    io.to(roomName).emit("chatMessage", payload);
 
-    res.status(201).json(payload);
+    res.status(201).json(populated);
   } catch (error) {
     console.log("Error in sendMessage controller: ", error.message);
     res.status(500).json({ error: "Internal server error" });

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -20,7 +20,7 @@ export const getMessages = async (req, res) => {
 
 export const sendMessage = async (req, res) => {
   try {
-    const {text, image, tempId} = req.body;
+    const {text, image, tempId, p2pSent} = req.body;
     const senderId = req.user._id;
     const roomName = req.params.roomName;
 
@@ -43,8 +43,13 @@ export const sendMessage = async (req, res) => {
 
     const payload = {...populated, tempId};    
 
-    // Emit to room
-    io.to(roomName).emit("chatMessage", payload);
+    //Only emit from server if message wasnt sent by p2p
+    if(!p2pSent) {
+      console.log(`[Server] Broadcasting message to ${roomName} as P2P fallback.`);
+      io.to(roomName).emit("chatMessage", payload);
+    } else {
+      console.log(`[Server] Message for ${roomName} persisted, broadcast skipped (sent via P2P).`);
+    }
 
     res.status(201).json(payload);
   } catch (error) {

--- a/backend/src/libs/socket.js
+++ b/backend/src/libs/socket.js
@@ -16,10 +16,38 @@ const io = new SocketServer(server, {
 io.on("connection", socket => {
   console.log("A user connected ", socket.id);
 
+  //WebRTC signalling
+  socket.on("webrtc-offer", ({offer, to}) => {
+    socket.to(to).emit("webrtc-offer", {offer, from: socket.id});
+  });
+
+  socket.on("webrtc-answer", (answer, to) => {
+    socket.to(to).emit("webrtc-answer", {answer, from: socket.id});
+  });
+
+  socket.on("webrtc-ice-candidate", (candidate, to) => {
+    socket.to(to).emit("webrtc-ice-candidate", {candidate, from: socket.id});
+  });
+
+
   // Handle joining rooms
   socket.on("join", (roomName) => {
     socket.join(roomName);
     console.log(`User ${socket.id} joined room: ${roomName}`);
+
+    // Get other users in the room
+    const clientsInRoom = io.sockets.adapter.rooms.get(roomName);
+    const otherUsers = [];
+    if (clientsInRoom) {
+      clientsInRoom.forEach(clientId => {
+        if (clientId !== socket.id) {
+          otherUsers.push(clientId);
+        }
+      });
+    }
+
+    // Send the list of existing users to the new user to initiate P2P
+    socket.emit("existing-room-users", { users: otherUsers });
     
     // Notify room members
     io.to(roomName).emit("userJoined", {

--- a/backend/src/libs/socket.js
+++ b/backend/src/libs/socket.js
@@ -21,11 +21,11 @@ io.on("connection", socket => {
     socket.to(to).emit("webrtc-offer", {offer, from: socket.id});
   });
 
-  socket.on("webrtc-answer", (answer, to) => {
+  socket.on("webrtc-answer", ({answer, to}) => {
     socket.to(to).emit("webrtc-answer", {answer, from: socket.id});
   });
 
-  socket.on("webrtc-ice-candidate", (candidate, to) => {
+  socket.on("webrtc-ice-candidate", ({candidate, to}) => {
     socket.to(to).emit("webrtc-ice-candidate", {candidate, from: socket.id});
   });
 

--- a/backend/src/libs/socket.js
+++ b/backend/src/libs/socket.js
@@ -18,14 +18,31 @@ io.on("connection", socket => {
 
   //WebRTC signalling
   socket.on("webrtc-offer", ({offer, to}) => {
+    const target = io.sockets.sockets.get(to);
+    if(!target || !offer) return; 
+
+    //ignore default room(socket id) and check if both share a room
+    const shareRoom = [...socket.rooms].some(r => r !== socket.id && target.rooms.has(r));
+    if(!shareRoom) return; //security check
+
     socket.to(to).emit("webrtc-offer", {offer, from: socket.id});
   });
 
   socket.on("webrtc-answer", ({answer, to}) => {
+    const target = io.sockets.sockets.get(to);
+    if(!target || !offer) return; 
+
+    const shareRoom = [...socket.rooms].some(r => r !== socket.id && target.rooms.has(r));
+    if(!shareRoom) return;
     socket.to(to).emit("webrtc-answer", {answer, from: socket.id});
   });
 
   socket.on("webrtc-ice-candidate", ({candidate, to}) => {
+    const target = io.sockets.sockets.get(to);
+    if(!target || !offer) return; 
+
+    const shareRoom = [...socket.rooms].some(r => r !== socket.id && target.rooms.has(r));
+    if(!shareRoom) return;
     socket.to(to).emit("webrtc-ice-candidate", {candidate, from: socket.id});
   });
 

--- a/backend/src/libs/socket.js
+++ b/backend/src/libs/socket.js
@@ -30,7 +30,7 @@ io.on("connection", socket => {
 
   socket.on("webrtc-answer", ({answer, to}) => {
     const target = io.sockets.sockets.get(to);
-    if(!target || !offer) return; 
+    if(!target || !answer) return; 
 
     const shareRoom = [...socket.rooms].some(r => r !== socket.id && target.rooms.has(r));
     if(!shareRoom) return;
@@ -39,7 +39,7 @@ io.on("connection", socket => {
 
   socket.on("webrtc-ice-candidate", ({candidate, to}) => {
     const target = io.sockets.sockets.get(to);
-    if(!target || !offer) return; 
+    if(!target || !candidate) return; 
 
     const shareRoom = [...socket.rooms].some(r => r !== socket.id && target.rooms.has(r));
     if(!shareRoom) return;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -200,11 +200,12 @@ function Chat({ roomType, user }) {
         const upsertMessage = (message) => {
           // If this message confirms a temporary one, replace it
           if (message.tempId && message.senderId._id === user.id) {
+            // Add the *new* permanent ID to the processed set
+            processedMessageIds.current.add(message._id);
+            
             setMessages(prev => 
               prev.map(m => m._id === message.tempId ? message : m)
             );
-            // Add the *new* permanent ID to the processed set
-            processedMessageIds.current.add(message._id);
           } else {
             // Otherwise, add it normally (it's from another user)
             addMessage(message);

--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -132,7 +132,12 @@ function Chat({ roomType, user }) {
 
           dataChannel.onmessage = event => {
             console.log("%c[P2P] Message received via DataChannel", "color: #22c55e;");
-            addMessage(JSON.parse(event.data));
+            try {
+              const message = JSON.parse(event.data)
+              addMessage(message);             
+            } catch (error) {
+              console.error("Failed to parse P2P message:", error);
+            }
           };
           dataChannel.onopen = () => {
             console.log(`Data channel with ${peerSocketId} opened.`);
@@ -155,7 +160,12 @@ function Chat({ roomType, user }) {
 
             dataChannel.onmessage = (e) => {
               console.log("%c[P2P] Message received via DataChannel", "color: #22c55e;");
-              addMessage(JSON.parse(e.data));
+              try {
+                const message = JSON.parse(e.data)
+                addMessage(message);             
+              } catch (error) {
+                console.error("Failed to parse P2P message:", error);
+              }
             };
             dataChannel.onopen = () => console.log(`Data channel with ${peerSocketId} opened.`);
           };

--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -65,8 +65,26 @@ function Chat({ roomType, user }) {
 
   // Helper to add a message to state, preventing duplicates
   const addMessage = (message) => {
-    if (!message._id || processedMessageIds.current.has(message._id)) return;
+    // Ignore if the message is invalid
+    if (!message || !message._id) return;
+
+    // 1. Check if we've already processed this message by its permanent ID
+    // 2. OR check if we've processed it by its temporary ID (from P2P)
+    if (
+      processedMessageIds.current.has(message._id) ||
+      (message.tempId && processedMessageIds.current.has(message.tempId))
+    ) {
+      // If either ID is already known, we've seen this message. Ignore it.
+      console.log(`[Deduplication] Ignored message: ${message.text}`);
+      return;
+    }
+
+    // This is a new message. Add BOTH of its IDs to the set for future checks.
     processedMessageIds.current.add(message._id);
+    if (message.tempId) {
+      processedMessageIds.current.add(message.tempId);
+    }
+    
     setMessages((prevMessages) => [...prevMessages, message]);
   };
 

--- a/frontend/src/components/JoinRoom.jsx
+++ b/frontend/src/components/JoinRoom.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { uniqueNamesGenerator, adjectives, colors, animals } from "unique-names-generator";
-import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 // Configure axios defaults

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waves",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waves",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waves",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
App now sends signalling information via sockets and then proceeds to attempt sending messages via P2P webRTC. If unable to send via P2P then sends via HTTP web-sockets. Still tries to send every message to server/DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer-to-peer chat via WebRTC: peer discovery in rooms, DataChannels for message delivery, ICE/STUN support, signaling/handshake, deduplication/upsert of temporary messages, and cleanup on leave/unmount.

* **Bug Fixes / Improvements**
  * Server broadcasts now include temporary message IDs so clients can reconcile/upsert temp messages with permanent ones.

* **Chores**
  * Version bumped across root, frontend, and backend to 2.0.6; removed an unused import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->